### PR TITLE
Feature/simple tree events

### DIFF
--- a/src/Core/API.jsx
+++ b/src/Core/API.jsx
@@ -26,7 +26,7 @@ export default class API {
     const startTime = date.toISOString();
 
     // Construct the URL with query parameters
-    const url = `${this.apiurl}?startTime=${encodeURIComponent(startTime)}&action=events&format=flat&sources=${encodeURIComponent(
+    const url = `${this.apiurl}?startTime=${encodeURIComponent(startTime)}&action=events&format=simpletree&sources=${encodeURIComponent(
       source
     )}`;
 

--- a/src/Core/EventTree.jsx
+++ b/src/Core/EventTree.jsx
@@ -10,17 +10,18 @@ class EventTree {
   }
 
   /**
-   * Build the tree directly from a flat list of events.
-   * Each event's `path` (e.g. "HEK>>Active Region>>HMI SHARP") describes its
-   * place in the hierarchy. Group nodes are created on demand from path
-   * segments; events that share a path collapse under one group with each
-   * event as a sibling leaf.
+   * Build the tree from the `format=simpletree` response: a flattree keyed by
+   * 2-piece category paths ("HEK>>Active Region") whose values are arrays of
+   * events. Empty categories arrive as `[]` so they remain visible in the
+   * tree. Each event carries its own `path` (e.g. "HEK>>Active Region>>HMI
+   * SHARP") describing the deeper hierarchy; group nodes for those deeper
+   * segments are created on demand and reused across events.
    *
-   * @param {Array}  events Flat array of event objects from the API.
-   * @param {string} source Top level event group name (HEK, CCMC, RHESSI, ...).
+   * @param {Object} eventsByCategory Dict {categoryPath: [event, ...]}.
+   * @param {string} source           Top level event group name (HEK, CCMC, ...).
    */
-  static make(events, source) {
-    const dict = {
+  static make(eventsByCategory, source) {
+    const flattree = {
       [source]: {
         label: source,
         path: source,
@@ -32,51 +33,73 @@ class EventTree {
       }
     };
 
-    events.forEach((e) => {
-      const parts = e.path.split(">>");
-
-      let parentId = null;
-      let cumulativePath = "";
-
-      parts.forEach((segment, idx) => {
-        cumulativePath = idx === 0 ? segment : `${cumulativePath}>>${segment}`;
-
-        if (!dict.hasOwnProperty(cumulativePath)) {
-          dict[cumulativePath] = {
-            label: segment,
-            path: cumulativePath,
-            id: cumulativePath,
-            state: "unchecked",
-            parent_id: parentId,
-            expand: idx < 2,
-            children: []
-          };
-
-          if (parentId != null) {
-            dict[parentId].children.push(cumulativePath);
-          }
-        }
-
-        parentId = cumulativePath;
-      });
-
-      const eventLabel = e.short_label ?? e.label;
-      const eventId = `${parentId}>>${e.id}`;
-
-      dict[eventId] = {
-        label: eventLabel,
-        path: `${parentId}>>${eventLabel}`,
-        id: eventId,
-        state: "unchecked",
-        parent_id: parentId,
-        expand: false,
-        data: e
-      };
-
-      dict[parentId].children.push(eventId);
+    // Seed every category branch the server reports, even when its list is
+    // empty, so the user always sees the full catalogue.
+    Object.keys(eventsByCategory).forEach((categoryPath) => { 
+      if (!flattree.hasOwnProperty(categoryPath)) {
+        const segments = categoryPath.split(">>");
+        flattree[categoryPath] = {
+          label: segments[segments.length - 1],
+          path: categoryPath,
+          id: categoryPath,
+          state: "unchecked",
+          parent_id: source,
+          expand: true,
+          children: []
+        };
+        flattree[source].children.push(categoryPath);
+      }
     });
 
-    return new EventTree(dict);
+    // Fold each event in using its own `path` field. Walks the cumulative
+    // segments, creating any missing group nodes, then appends the event leaf.
+    Object.values(eventsByCategory).forEach((eventList) => {
+      eventList.forEach((e) => {
+        const parts = e.path.split(">>");
+
+        let parentId = null;
+        let cumulativePath = "";
+
+        parts.forEach((segment, idx) => {
+          cumulativePath = idx === 0 ? segment : `${cumulativePath}>>${segment}`;
+
+          if (!flattree.hasOwnProperty(cumulativePath)) {
+            flattree[cumulativePath] = {
+              label: segment,
+              path: cumulativePath,
+              id: cumulativePath,
+              state: "unchecked",
+              parent_id: parentId,
+              expand: idx < 2,
+              children: []
+            };
+
+            if (parentId != null) {
+              flattree[parentId].children.push(cumulativePath);
+            }
+          }
+
+          parentId = cumulativePath;
+        });
+
+        const eventLabel = e.short_label ?? e.label;
+        const eventId = `${parentId}>>${e.id}`;
+
+        flattree[eventId] = {
+          label: eventLabel,
+          path: `${parentId}>>${eventLabel}`,
+          id: eventId,
+          state: "unchecked",
+          parent_id: parentId,
+          expand: false,
+          data: e
+        };
+
+        flattree[parentId].children.push(eventId);
+      });
+    });
+
+    return new EventTree(flattree);
   }
 
   toggleCheckbox(id) {

--- a/src/HelioviewerEventTree.jsx
+++ b/src/HelioviewerEventTree.jsx
@@ -165,6 +165,7 @@ function HelioviewerEventTree({
   };
 
   let hasEvents = eventTree.getEventCount(source) > 0;
+  let hasCategories = eventTree[source].children.length > 0;
 
   if (!hasEvents) {
     nodeContainerStyle = {
@@ -186,7 +187,7 @@ function HelioviewerEventTree({
 
   let eventTreeRender = <span style={{ color: "red" }}>No events</span>;
 
-  if (hasEvents) {
+  if (hasCategories) {
     eventTreeRender = eventTree[source].children.map((cid) => {
       return (
         <Node
@@ -208,6 +209,7 @@ function HelioviewerEventTree({
       <div style={nodeContainerStyle}>
         <SourceHeader
           hasEvents={hasEvents}
+          hasCategories={hasCategories}
           checked={eventTree[source].state}
           onCheckedUpdate={() => toggleCheckbox(source)}
           onHeaderHover={() => {

--- a/src/SourceHeader.jsx
+++ b/src/SourceHeader.jsx
@@ -13,6 +13,7 @@ import Checkbox from "./Checkbox.jsx";
 function SourceHeader({
   source,
   hasEvents,
+  hasCategories,
   eventsDate,
   checked,
   onCheckedUpdate,
@@ -49,7 +50,7 @@ function SourceHeader({
           <span onMouseEnter={onHeaderHover} onMouseLeave={offHeaderHover} data-testid={`event-tree-label-${source}`}>
             {source}
           </span>
-          {hasEvents ? (
+          {hasCategories ? (
             <Checkbox
               dataTestId={`event-tree-checkbox-${source}`}
               state={checked}


### PR DESCRIPTION
- API now requests action=events&format=simpletree, which returns a
  dict keyed by 2-piece category paths (e.g. "HEK>>Active Region")
  whose values are arrays of events. Empty categories arrive as []
  and stay visible in the tree.
- EventTree.make rewritten to consume the dict directly: seed every
  category branch from the keys, then fold events in via their own
  `path` field. No more hardcoded category list.
- Fix render gates that hid the tree and source-level checkbox when
  a source had zero events but non-empty categories (e.g. RHESSI
  with empty Solar Flares). Gate on hasCategories instead of
  hasEvents; date color still reflects hasEvents.